### PR TITLE
No `sys.stdin.buffer` for Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ else:
 
 setup(
 	name='xopen',
-	version='0.3.2',
+	version='0.3.3',
 	author='Marcel Martin',
 	author_email='mail@marcelm.net',
 	url='https://github.com/marcelm/xopen/',

--- a/xopen.py
+++ b/xopen.py
@@ -197,13 +197,16 @@ def xopen(filename, mode='r', compresslevel=6):
 
 	# standard input and standard output handling
 	if filename == '-':
-		return dict(
-			r=sys.stdin,
-			rt=sys.stdin,
-			rb=sys.stdin.buffer,
-			w=sys.stdout,
-			wt=sys.stdout,
-			wb=sys.stdout.buffer)[mode]
+		if not _PY3:
+			return dict(r=sys.stdin, w=sys.stdout)[mode]
+		else:
+			return dict(
+				r=sys.stdin,
+				rt=sys.stdin,
+				rb=sys.stdin.buffer,
+				w=sys.stdout,
+				wt=sys.stdout,
+				wb=sys.stdout.buffer)[mode]
 
 	if filename.endswith('.bz2'):
 		if bz2 is None:


### PR DESCRIPTION
Ran into an issue when using `xopen.xopen('-', 'r')` in Python 2:

```
>>> xopen.xopen('-', 'r')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-5448057e1aea> in <module>()
----> 1 xopen.xopen('-', 'r')
xopen.pyc in xopen(filename, mode, compresslevel)
    201                         r=sys.stdin,
    202                         rt=sys.stdin,
--> 203                         rb=sys.stdin.buffer,
    204                         w=sys.stdout,
    205                         wt=sys.stdout,

AttributeError: 'file' object has no attribute 'buffer'
```

Fix is to not create the mode lookup dictionary with the `.buffer` options if it's a non-Python 3 environment, which is what the PR does.