### PR TITLE
Open decompression process in gzip subprocess by default.

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -205,6 +205,13 @@ class PipedGzipReader(Closing):
         self.process.wait()
         self._raise_if_error()
 
+    def __next__(self):
+        line = self._file.readline()
+        if line:
+            return line
+        else:
+            raise StopIteration()
+
     def _raise_if_error(self):
         """
         Raise IOError if process is not running anymore and the

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -230,6 +230,9 @@ class PipedGzipReader(Closing):
         self._raise_if_error()
         return data
 
+    def readinto(self, *args):
+        data = self._file.readinto(*args)
+        return data
 
 if bz2 is not None:
     class ClosingBZ2File(bz2.BZ2File, Closing):

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -266,8 +266,6 @@ def _open_xz(filename, mode):
 
 
 def _open_gz(filename, mode, compresslevel, threads):
-    if _PY3 and 'r' in mode:
-        return gzip.open(filename, mode)
     if sys.version_info[:2] == (2, 7):
         buffered_reader = io.BufferedReader
         buffered_writer = io.BufferedWriter
@@ -279,7 +277,10 @@ def _open_gz(filename, mode, compresslevel, threads):
             return PipedGzipReader(filename, mode)
         except OSError:
             # gzip not installed
-            return buffered_reader(gzip.open(filename, mode))
+            if _PY3:
+                return gzip.open(filename, mode)
+            else:
+                return buffered_reader(gzip.open(filename, mode))
     else:
         try:
             return PipedGzipWriter(filename, mode, compresslevel, threads=threads)


### PR DESCRIPTION
Stumbled across this library this morning. Wow! Such concise, well-written and readable code. This is one of the best python projects I have ever seen!

I am currently writing a simple fastqsplitter in python that reads a fastq file and splits it into multiple others. This means it does decompression (for the input) and compression (for the outputs) simultaneously.

Unfortunately it is slower than the [scala implementation](https://github.com/biopet/fastqsplitter) because xopen uses `gzip.open` by default when using python 3. This means the business logic of moving the data around and the decompression are done in the same thread. This creates a bottleneck even on my work PC with a core i7-6700 (which should have ample single threaded power). 

With this PR xopen defaults to decompress opened files in separate gzip processes. This increases performance.

before:
```
time ./fastqsplitter.py -i /data/test/U0b_TGACCA_L001_R1.fastq.gz -o split.1.fq.gz -o split.2.fq.gz -o split.3.fq.gz -o split.4.fq.gz -o split.5.fq.gz -c 5

real    1m59.174s
user    8m28.572s
sys     0m12.200s
```

After
```
time ./fastqsplitter.py -i /data/test/U0b_TGACCA_L001_R1.fastq.gz -o split.1.fq.gz -o split.2.fq.gz -o split.3.fq.gz -o split.4.fq.gz -o split.5.fq.gz -c 5

real    1m29.463s
user    8m35.296s
sys     0m15.980s
```
~~Total cpu time has increased, but real time has dropped because of the better parallelization.
This 30 second difference also manifests itself when I use `-c 1`.
It is a trade off, but the 30 seconds extra total cpu time (6% extra compute time) are not as significant compared to the 30 seconds decrease in real time (25% faster finish)~~

EDIT: I made the PipedGzipReader a proper iterator. Now it is just plain faster. No drawbacks. To use the iterator.
```python
myfile = xopen('myfile.txt.gz')
While True:
    try:
        line=next(myfile)
    except StopIteration:
        break
    # Fancy operations with line here.

```

EDIT: You could also use a for loop.


And this is opening one fastq file. If you open two (cutadapt) then it should become even faster in real time.

Hope this helps!
