### PR TITLE
Improve speed for pipedgzip reader.

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -215,10 +215,7 @@ class PipedGzipReader(Closing):
         self._raise_if_error()
 
     def __iter__(self):
-        for line in self._file:
-            yield line
-        self.process.wait()
-        self._raise_if_error()
+        return self._file
 
     def _raise_if_error(self):
         """


### PR DESCRIPTION
Hi, I have been doing some major performance nerding lately as part of my work on fastqsplitter.

I discovered that
```
with open('my_file.txt', 'rb') as file_handler:
     for line in file_handler:
        # do stuff per line
        pass
```
Is the fastest way to iterate over files in python. `file_handle.readline()` or `next(file_handle)` exhibits some overhead.
I noticed that the PipedGzipReader uses a lot of cpu time when iterating over it that way. This PR fixes that by letting `__iter__` return `self._file` as that is already an iterator.

I did some benchmarks with this script:
```
#/usr/bin/env python3

import sys
import xopen

with xopen.xopen(sys.argv[1]) as file_h:
    for line in file_h:
        pass
```

I conducted some testing with [hyperfine](https://github.com/sharkdp/hyperfine) (installable via conda). It is quite a nice tool. It does several runs and allows you to set a warmup so the file is thoroughly cached in memory before the actual tests start.

Before:
```
hyperfine -w 3 "python3 test.py ~/test/big.fastq.gz"
Benchmark #1: python3 test.py ~/test/big.fastq.gz
  Time (mean ± σ):      8.263 s ±  0.239 s    [User: 15.095 s, System: 1.841 s]
  Range (min … max):    7.982 s …  8.657 s    10 runs
 ```

after:
```
hyperfine -w 3 "python3 test.py ~/test/big.fastq.gz"
Benchmark #1: python3 test.py ~/test/big.fastq.gz
  Time (mean ± σ):      5.847 s ±  0.177 s    [User: 12.541 s, System: 1.801 s]
  Range (min … max):    5.567 s …  6.212 s    10 runs
```

Xopen still crashes when you give it a corrupt gzip file. The output is the same. All the tests succeed. The speedup is quite nice: >25%. And the resulting code is smaller.

What more do you need? :wink:
