### PR TITLE
Improve speed of read method. Improve speed of readinto. Fix readline method. Fix readable() method.

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -245,12 +245,7 @@ class PipedGzipReader(Closing):
         return self._file.readinto(*args)
 
     def readline(self, *args):
-        data = self._file.readline(*args)
-        if len(args) == 0 or args[0] <= 0:
-            # wait for process to terminate until we check the exit code
-            self.process.wait()
-        self._raise_if_error()
-        return data
+        return self._file.readline(*args)
 
     def seekable(self):
         return self._file.seekable()

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -234,12 +234,7 @@ class PipedGzipReader(Closing):
             raise IOError(message)
 
     def read(self, *args):
-        data = self._file.read(*args)
-        if len(args) == 0 or args[0] <= 0:
-            # wait for process to terminate until we check the exit code
-            self.process.wait()
-        self._raise_if_error()
-        return data
+        return self._file.read(*args)
 
     def readinto(self, *args):
         return self._file.readinto(*args)

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -242,8 +242,7 @@ class PipedGzipReader(Closing):
         return data
 
     def readinto(self, *args):
-        data = self._file.readinto(*args)
-        return data
+        return self._file.readinto(*args)
 
     def readline(self, *args):
         data = self._file.readline(*args)

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -253,9 +253,13 @@ class PipedGzipReader(Closing):
     def peek(self, n=None):
         return self._file.peek(n)
 
-    if _PY3:
-        def readable(self):
+    def readable(self):
+        if _PY3:
             return self._file.readable()
+        else:
+            return NotImplementedError(
+                "Python 2 does not support the readable() method."
+            )
 
     def writable(self):
         return self._file.writable()


### PR DESCRIPTION
## Faster read()

in the same vein as #14 .


I removed all the checking from the read method. 

I tested it with:
```Python
#/usr/bin/env python3

import sys
import xopen

with xopen.xopen(sys.argv[1]) as file_h:
    block = True
    while block:
        block = file_h.read(4096)
```

Test results
before:
```
hyperfine -w 3 "python3 test.py ~/test/big.fastq.gz"
Benchmark #1: python3 test.py ~/test/big.fastq.gz
  Time (mean ± σ):      4.616 s ±  0.066 s    [User: 9.714 s, System: 1.690 s]
  Range (min … max):    4.519 s …  4.737 s    10 runs
 ```
After:
```
 hyperfine -w 3 "python3 test.py ~/test/big.fastq.gz"
Benchmark #1: python3 test.py ~/test/big.fastq.gz
  Time (mean ± σ):      4.617 s ±  0.069 s    [User: 8.666 s, System: 1.404 s]
  Range (min … max):    4.518 s …  4.705 s    10 runs
```
`User` equals total cpu time.
Before: 9.7 - 6.8 = 2.9 cpu seconds python overhead.
After: 8.7 - 6.8 = 1.9 cpu seconds python overhead. Pretty significant uplift.

## Fixing readline()
the original `readline()` implementation hanged. This reads one line, but then it waits for the process to finish. Process fills the kernel buffer for that certain process, and then the process stops until there is room in the buffer. `wait()` waits forever and `readline()` never returns data. This is fixed. Readline now works as expected.
This was probably missed in the tests if files smaller than 65 kb are used.

## Faster readinto
This is used in cutadapt. The variable assignment is skipped, this should save some (very small amount of) time. 

## Fix readable method.
This method existed in the PipedGzipReader class in python3 but not in python2. This is not considered best practice. It now always exists and raises a NotImplementedError in python2.
