### PR TITLE
limit the number of threads also for reading

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -198,9 +198,11 @@ class PipedGzipReader(Closing):
             raise ValueError("Mode is '{0}', but it must be 'r', 'rt' or 'rb'".format(mode))
         if threads is None:
             threads = min(_available_cpu_count(), 4)
+        
+        pigz_args = ['pigz', '-cd', path]
         if threads != 0:
             pigz_args += ['-p', str(threads)]
-        self.process = Popen(['pigz', '-cd', path] + pigz_args, stdout=PIPE, stderr=PIPE)
+        self.process = Popen(pigz_args, stdout=PIPE, stderr=PIPE)
         self.name = path
         if _PY3 and 'b' not in mode:
             self._file = io.TextIOWrapper(self.process.stdout)

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -190,13 +190,17 @@ class PipedGzipReader(Closing):
     also faster than gzip when reading (three times faster).
     """
 
-    def __init__(self, path, mode='r'):
+    def __init__(self, path, mode='r', threads=None):
         """
         Raise an OSError when pigz could not be found.
         """
         if mode not in ('r', 'rt', 'rb'):
             raise ValueError("Mode is '{0}', but it must be 'r', 'rt' or 'rb'".format(mode))
-        self.process = Popen(['pigz', '-cd', path], stdout=PIPE, stderr=PIPE)
+        if threads is None:
+            threads = min(_available_cpu_count(), 4)
+        if threads != 0:
+            pigz_args += ['-p', str(threads)]
+        self.process = Popen(['pigz', '-cd', path] + pigz_args, stdout=PIPE, stderr=PIPE)
         self.name = path
         if _PY3 and 'b' not in mode:
             self._file = io.TextIOWrapper(self.process.stdout)
@@ -316,7 +320,7 @@ def _open_gz(filename, mode, compresslevel, threads):
         exc = OSError
     if 'r' in mode:
         try:
-            return PipedGzipReader(filename, mode)
+            return PipedGzipReader(filename, mode, threads=threads)
         except exc:
             # pigz is not installed
             return buffered_reader(gzip.open(filename, mode))


### PR DESCRIPTION
using the same logic as for writing

this is really important for me (assuming that it works :) ) since cutadapt can not be used on restrictive cluster environments otherwise (on out cluster jobs are killed if they take more resources than requested -- and I can't request all CPUs).

