### PR TITLE
Limit thread usage to 1 for decompressing.

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -198,16 +198,17 @@ class PipedGzipReader(Closing):
             raise ValueError("Mode is '{0}', but it must be 'r', 'rt' or 'rb'".format(mode))
 
         pigz_args = ['pigz', '-cd', path]
-        if threads:  # Check if threads is not 0 or None.
-            pigz_args += ['-p', str(threads)]
-        else:
+
+        if threads is None or threads == 0:
             # Single threaded behaviour by default because:
             # - Using a single thread to read a file is the least unexpected
             #   behaviour. (For users of xopen, who do not know which backend is used.)
-            # - There is quite a substantial overhead (+25% cpu time) when
+            # - There is quite a substantial overhead (+25% CPU time) when
             #   using multiple threads while there is only a 10% gain in wall
-            #   clock time. This is a bad trade off.
-            pigz_args += ['-p', '1']
+            #   clock time.
+            threads = 1
+
+        pigz_args += ['-p', str(threads)]
 
         self.process = Popen(pigz_args, stdout=PIPE, stderr=PIPE)
         self.name = path

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -198,7 +198,7 @@ class PipedGzipReader(Closing):
             raise ValueError("Mode is '{0}', but it must be 'r', 'rt' or 'rb'".format(mode))
 
         pigz_args = ['pigz', '-cd', path]
-        if threads != 0:
+        if threads != 0 and threads is not None:
             pigz_args += ['-p', str(threads)]
         self.process = Popen(pigz_args, stdout=PIPE, stderr=PIPE)
         self.name = path

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -198,7 +198,7 @@ class PipedGzipReader(Closing):
             raise ValueError("Mode is '{0}', but it must be 'r', 'rt' or 'rb'".format(mode))
 
         pigz_args = ['pigz', '-cd', path]
-        if threads != 0 and threads is not None:
+        if threads:  # Check if threads is not 0 or None.
             pigz_args += ['-p', str(threads)]
         self.process = Popen(pigz_args, stdout=PIPE, stderr=PIPE)
         self.name = path

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -199,7 +199,7 @@ class PipedGzipReader(Closing):
 
         pigz_args = ['pigz', '-cd', path]
 
-        if threads is None or threads == 0:
+        if not threads:
             # Single threaded behaviour by default because:
             # - Using a single thread to read a file is the least unexpected
             #   behaviour. (For users of xopen, who do not know which backend is used.)

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -200,6 +200,15 @@ class PipedGzipReader(Closing):
         pigz_args = ['pigz', '-cd', path]
         if threads:  # Check if threads is not 0 or None.
             pigz_args += ['-p', str(threads)]
+        else:
+            # Single threaded behaviour by default because:
+            # - Using a single thread to read a file is the least unexpected
+            #   behaviour. (For users of xopen, who do not know which backend is used.)
+            # - There is quite a substantial overhead (+25% cpu time) when
+            #   using multiple threads while there is only a 10% gain in wall
+            #   clock time. This is a bad trade off.
+            pigz_args += ['-p', '1']
+
         self.process = Popen(pigz_args, stdout=PIPE, stderr=PIPE)
         self.name = path
         if _PY3 and 'b' not in mode:

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -196,9 +196,7 @@ class PipedGzipReader(Closing):
         """
         if mode not in ('r', 'rt', 'rb'):
             raise ValueError("Mode is '{0}', but it must be 'r', 'rt' or 'rb'".format(mode))
-        if threads is None:
-            threads = min(_available_cpu_count(), 4)
-        
+
         pigz_args = ['pigz', '-cd', path]
         if threads != 0:
             pigz_args += ['-p', str(threads)]


### PR DESCRIPTION
Pigz does not use more than 4 threads when decompressing. Therefore defaulting to 4 threads is not necessary.

This is more of a technical debt thing, and does not warrant a new release. Still every line removed is a line that does not need to be maintained.

By the way, should `def _available_cpu_count():` still be there? Is there a use case that `multiprocessing.cpu_count()` does not cover? (Maybe python2, but does that need to be supported anymore? Cutadapt does not support python2 anymore.)
