### PR TITLE
Allow threads=0 to mean that no external pigz/gzip should be run

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,8 @@ v0.8.4
   it would use extra I/O processes, which slightly reduces wall-clock time,
   but increases CPU time. Single-core decompression with ``pigz`` is still
   about twice as fast as regular ``gzip``.
+* Allow ``threads=0`` for specifying that no external ``pigz``/``gzip``
+  process should be used (then regular ``gzip.open()`` is used instead).
 
 v0.8.3
 ~~~~~~

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -335,25 +335,25 @@ def _open_gz(filename, mode, compresslevel, threads):
         exc = OSError
 
     if 'r' in mode:
-        def with_threads():
+        def open_with_threads():
             return PipedGzipReader(filename, mode, threads=threads)
 
-        def without_threads():
+        def open_without_threads():
             return buffered_reader(gzip.open(filename, mode))
     else:
-        def with_threads():
+        def open_with_threads():
             return PipedGzipWriter(filename, mode, compresslevel, threads=threads)
 
-        def without_threads():
+        def open_without_threads():
             return buffered_writer(gzip.open(filename, mode, compresslevel=compresslevel))
 
     if threads == 0:
-        return without_threads()
+        return open_without_threads()
     try:
-        return with_threads()
+        return open_with_threads()
     except exc:
         # pigz is not installed, use fallback
-        return without_threads()
+        return open_without_threads()
 
 
 def xopen(filename, mode='r', compresslevel=6, threads=None):

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -309,6 +309,20 @@ def test_write_pigz_threads(tmpdir):
         assert f.read() == 'hello'
 
 
+if sys.version_info[0] >= 3:
+    def test_read_gzip_no_threads():
+        import gzip
+        with xopen("tests/hello.gz", "rb", threads=0) as f:
+            assert isinstance(f, gzip.GzipFile), f
+
+
+    def test_write_gzip_no_threads(tmpdir):
+        import gzip
+        path = str(tmpdir.join("out.gz"))
+        with xopen(path, "wb", threads=0) as f:
+            assert isinstance(f, gzip.GzipFile), f
+
+
 def test_write_stdout():
     f = xopen('-', mode='w')
     print("Hello", file=f)


### PR DESCRIPTION
Instead, regular gzip.open() is used.

I’m planning to use this to help solving marcelm/cutadapt#290.