### PR TITLE
Fix linting errors

### DIFF
--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -314,7 +314,6 @@ if sys.version_info[0] >= 3:
         with xopen("tests/hello.gz", "rb", threads=0) as f:
             assert isinstance(f, gzip.GzipFile), f
 
-
     def test_write_gzip_no_threads(tmpdir):
         import gzip
         path = str(tmpdir.join("out.gz"))


### PR DESCRIPTION
The latest master commit failed due to lint errors. Probably because the linting PR and the threads functionality PR were made simultaneously. Hence the threads functionality was not checked against the linter before being merged.

Apparantly the linter thought _open_gz was too complex. Probably because of the function definitions. Here is my take on it. I think it is a bit easier to understand and it is also less complex (according to the linter). What do you think?