### PR TITLE
Correctly fall back to gzip.open when permission denied occurs for external program

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -341,7 +341,7 @@ class PipedGzipReader(PipedCompressionReader):
     def __init__(self, path, mode='r', threads=None):
         try:
             super().__init__(path, "pigz", mode, "-p", threads)
-        except FileNotFoundError:
+        except OSError:
             super().__init__(path, "gzip", mode, None, threads)
 
 
@@ -366,7 +366,7 @@ class PipedGzipWriter(PipedCompressionWriter):
             raise ValueError("compresslevel must be between 1 and 9")
         try:
             super().__init__(path, "pigz", mode, compresslevel, "-p", threads)
-        except FileNotFoundError:
+        except OSError:
             super().__init__(path, "gzip", mode, compresslevel, None, threads)
 
 
@@ -433,17 +433,17 @@ def _open_gz(filename, mode, compresslevel, threads):
             if 'r' in mode:
                 try:
                     return PipedIGzipReader(filename, mode)
-                except (FileNotFoundError, ValueError):
+                except (OSError, ValueError):
                     # No igzip installed or version does not support reading
                     # concatenated files.
                     return PipedGzipReader(filename, mode, threads=threads)
             else:
                 try:
                     return PipedIGzipWriter(filename, mode, compresslevel)
-                except (FileNotFoundError, ValueError):
+                except (OSError, ValueError):
                     # No igzip installed or compression level higher than 3
                     return PipedGzipWriter(filename, mode, compresslevel, threads=threads)
-        except FileNotFoundError:
+        except OSError:
             pass  # We try without threads.
 
     if 'r' in mode:

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -50,8 +50,8 @@ def lacking_pigz_permissions(tmp_path):
     """
     pigz_path = shutil.which("pigz")
     if pigz_path:
-        shutil.copy(pigz_path, tmp_path)
-        os.chmod(tmp_path / "pigz", 0)
+        shutil.copy(pigz_path, str(tmp_path))
+        os.chmod(str(tmp_path / "pigz"), 0)
 
     path = os.environ["PATH"]
     os.environ["PATH"] = str(tmp_path)


### PR DESCRIPTION
This has been reported to me by a Cutadapt user via e-mail.

When an external program has weird permissions, we currently fail with `PermissionError: [Errno 13] Permission denied: 'pigz'` (or similar). This PR changes that by catching `OSError` instead of only `FileNotFoundError` (`PermissionError` is a subclass of `OSError`). 