### PR TITLE
Type annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,12 @@ jobs:
       script: flake8 src/ tests/
 
     - stage: test
+      name: mypy
+      python: "3.6"
+      install: python3 -m pip install mypy
+      script: mypy src/
+
+    - stage: test
       name: igzip
       python: "3.6"
       install:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     license='MIT',
     package_dir={'': 'src'},
     packages=find_packages('src'),
+    package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
     },

--- a/src/xopen/_version.pyi
+++ b/src/xopen/_version.pyi
@@ -1,0 +1,4 @@
+# The _version.py file is generated on installation. By including this stub,
+# we can run mypy without having to install the package.
+
+version: str

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py35,py36,py37,py38,py39,pypy3
+envlist = flake8,mypy,py35,py36,py37,py38,py39,pypy3
 
 [testenv]
 deps = pytest
@@ -10,6 +10,11 @@ commands = pytest --doctest-modules --pyargs src/xopen tests
 basepython = python3.6
 deps = flake8
 commands = flake8 src/ tests/
+
+[testenv:mypy]
+basepython = python3.6
+deps = mypy
+commands = mypy src/
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
This adds type annotations to almost all functions. The `xopen()` function itself is annotated as having the `IO` return type, which is not perfect, but should be good enough for now.

See #22