### PR TITLE
Fix ResourceWarnings when opening many piped processes

### DIFF
--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -93,7 +93,10 @@ def _set_pipe_size_to_max(fd: int) -> None:
     """
     if not hasattr(fcntl, "F_SETPIPE_SZ") or not _MAX_PIPE_SIZE:
         return
-    fcntl.fcntl(fd, fcntl.F_SETPIPE_SZ, _MAX_PIPE_SIZE)  # type: ignore
+    try:
+        fcntl.fcntl(fd, fcntl.F_SETPIPE_SZ, _MAX_PIPE_SIZE)  # type: ignore
+    except OSError:
+        pass
 
 
 def _can_read_concatenated_gz(program: str) -> bool:

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -16,7 +16,7 @@ import pathlib
 import subprocess
 import tempfile
 from abc import ABC, abstractmethod
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, DEVNULL
 from typing import Optional, TextIO, AnyStr, IO
 
 from ._version import version as __version__
@@ -168,7 +168,6 @@ class PipedCompressionWriter(Closing):
 
         # TODO use a context manager
         self.outfile = open(path, mode)
-        self.devnull = open(os.devnull, mode)
         self.closed = False
         self.name = path
         self._mode = mode
@@ -180,10 +179,9 @@ class PipedCompressionWriter(Closing):
         self._threads = threads
         try:
             self.process = self._open_process(
-                mode, compresslevel, threads, self.outfile, self.devnull)
+                mode, compresslevel, threads, self.outfile)
         except OSError:
             self.outfile.close()
-            self.devnull.close()
             raise
         assert self.process.stdin is not None
         _set_pipe_size_to_max(self.process.stdin.fileno())
@@ -204,7 +202,6 @@ class PipedCompressionWriter(Closing):
 
     def _open_process(
         self, mode: str, compresslevel: Optional[int], threads: int, outfile: TextIO,
-        devnull: TextIO
     ) -> Popen:
         program_args = [self._program]
         if threads != 0 and self._threads_flag is not None:
@@ -213,7 +210,7 @@ class PipedCompressionWriter(Closing):
         if 'w' in mode and compresslevel is not None:
             extra_args += ['-' + str(compresslevel)]
 
-        kwargs = dict(stdin=PIPE, stdout=outfile, stderr=devnull)
+        kwargs = dict(stdin=PIPE, stdout=outfile, stderr=DEVNULL)
 
         # Setting close_fds to True in the Popen arguments is necessary due to
         # <http://bugs.python.org/issue12786>.
@@ -235,7 +232,6 @@ class PipedCompressionWriter(Closing):
         self._file.close()
         retcode = self.process.wait()
         self.outfile.close()
-        self.devnull.close()
         if retcode != 0:
             raise OSError(
                 "Output {} process terminated with exit code {}".format(self._program, retcode))

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -442,3 +442,14 @@ def test_pipesize_changed(tmpdir):
 def test_xopen_falls_back_to_gzip_open(lacking_pigz_permissions):
     with xopen("tests/file.txt.gz", "rb") as f:
         assert f.readline() == CONTENT_LINES[0].encode("utf-8")
+
+
+def test_open_many_gzip_writers(tmp_path):
+    files = []
+    for i in range(1, 61):
+        path = tmp_path / "{:03d}.txt.gz".format(i)
+        f = xopen(path, "wb", threads=2)
+        f.write(b"hello")
+        files.append(f)
+    for f in files:
+        f.close()

--- a/tests/test_xopen.py
+++ b/tests/test_xopen.py
@@ -194,8 +194,10 @@ def test_pipedgzipwriter_has_iter_method(tmpdir):
 
 
 def test_iter_without_with(fname):
-    it = iter(xopen(fname, "rt"))
+    f = xopen(fname, "rt")
+    it = iter(f)
     assert CONTENT_LINES[0] == next(it)
+    f.close()
 
 
 def test_pipedgzipreader_iter_without_with():

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,8 @@ commands = mypy src/
 max-line-length = 99
 max-complexity = 10
 extend_ignore = E731
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__


### PR DESCRIPTION
When many subprocesses are spawned (more than 50 in my tests), `fcntl.fcntl` starts to raise an OSError (permission denied). This is not handled in the PipedCompressionReader/-Writer __init__ methods, so the OSError is propagated and then the fallback mechanism finally opens the file using regular gzip.open. However, the Popen object is never closed correctly if this happens, leading to the ResourceWarning.

This fixes https://github.com/marcelm/cutadapt/issues/493

I’m opening this PR only for notification. I’ll need to merge this and make a new release soon.