### PR TITLE
Enable reading gzip files faster with the python main thread using python-isal.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           fi
     - name: Install isal
       if: matrix.with-isal && !startsWith(matrix.os, 'macos')
-      run: sudo apt-get install isal
+      run: sudo apt-get install isal libisal-dev
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -54,6 +54,10 @@ jobs:
       run: python -m pip install tox
     - name: Test
       run: tox -e py
+      if: !matrix.with-isal
+    - name: Test with isal
+      run: tox -e isal
+      if: matrix.with-isal
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       run: python -m pip install tox
     - name: Test
       run: tox -e py
-      if: !matrix.with-isal
+      if: matrix.with-isal == null
     - name: Test with isal
       run: tox -e isal
       if: matrix.with-isal

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,12 @@ when reading ``.gz`` files, so it is used both for reading and writing if it is
 available. For gzip compression levels 1 to 3,
 `igzip <https://github.com/intel/isa-l/>`_ is used for an even greater speedup.
 
+For use cases where using only the main thread is desired xopen can be used
+with ``threads=0`` and uses `python-isal
+<https://github.com/pycompression/python-isal>`_ (which binds isa-l) for
+fast decompression and fast compression for levels 1 to 3. For compression
+levels of 4 and higher ``gzip.open`` is used.
+
 This module has originally been developed as part of the `Cutadapt
 tool <https://cutadapt.readthedocs.io/>`_ that is used in bioinformatics to
 manipulate sequencing data. It has been in successful use within that software

--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,10 @@ available. For gzip compression levels 1 to 3,
 `igzip <https://github.com/intel/isa-l/>`_ is used for an even greater speedup.
 
 For use cases where using only the main thread is desired xopen can be used
-with ``threads=0`` and uses `python-isal
-<https://github.com/pycompression/python-isal>`_ (which binds isa-l) for
-fast decompression and fast compression for levels 1 to 3. For compression
-levels of 4 and higher ``gzip.open`` is used.
+with ``threads=0``. This will use `python-isal
+<https://github.com/pycompression/python-isal>`_ (which binds isa-l) if
+python-isal is installed int virtual environment (``pip install isal``). If
+python-isal is not available ``gzip.open`` is used.
 
 This module has originally been developed as part of the `Cutadapt
 tool <https://cutadapt.readthedocs.io/>`_ that is used in bioinformatics to

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,10 @@ available. For gzip compression levels 1 to 3,
 For use cases where using only the main thread is desired xopen can be used
 with ``threads=0``. This will use `python-isal
 <https://github.com/pycompression/python-isal>`_ (which binds isa-l) if
-python-isal is installed int virtual environment (``pip install isal``). If
-python-isal is not available ``gzip.open`` is used.
+python-isal is installed. For installation instructions for python-isal please
+checkout the `python-isal homepage
+<https://github.com/pycompression/python-isal>`_. If python-isal is not
+available ``gzip.open`` is used.
 
 This module has originally been developed as part of the `Cutadapt
 tool <https://cutadapt.readthedocs.io/>`_ that is used in bioinformatics to

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
+        'isal': ['isal>=0.2.0']
     },
     python_requires='>=3.5',
     classifiers=[

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -28,8 +28,7 @@ except ImportError:
     lzma = None  # type: ignore
 
 try:
-    from isal import igzip
-    from isal import isal_zlib
+    from isal import igzip, isal_zlib  # type: ignore
 except ImportError:
     igzip = None
     isal_zlib = None

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -497,7 +497,7 @@ def _open_gz_external(filename, mode, compresslevel, threads):
 def _open_gz(filename, mode: str, compresslevel, threads):
     if threads != 0:
         try:
-            _open_gz_external(filename, mode, compresslevel, threads)
+            return _open_gz_external(filename, mode, compresslevel, threads)
         except OSError:
             pass  # We try without threads.
 

--- a/src/xopen/__init__.py
+++ b/src/xopen/__init__.py
@@ -477,7 +477,7 @@ def _open_xz(filename, mode: str) -> IO:
     return lzma.open(filename, mode)
 
 
-def _open_gz_external(filename, mode, threads, compresslevel):
+def _open_gz_external(filename, mode, compresslevel, threads):
     if 'r' in mode:
         try:
             return PipedIGzipReader(filename, mode)

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ skip_install = true
 [testenv:mypy]
 basepython = python3.6
 deps = mypy
-commands = mypy src/
+commands = mypy --ignore-missing-imports src/
 skip_install = true
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -27,14 +27,13 @@ skip_install = true
 [testenv:mypy]
 basepython = python3.6
 deps = mypy
-commands = mypy --ignore-missing-imports src/
+commands = mypy src/
 skip_install = true
 
 [flake8]
 max-line-length = 99
 max-complexity = 10
 extend_ignore = E731
-skip_install = true
 
 [coverage:report]
 exclude_lines =

--- a/tox.ini
+++ b/tox.ini
@@ -22,16 +22,19 @@ deps =
 basepython = python3.6
 deps = flake8
 commands = flake8 src/ tests/
+skip_install = true
 
 [testenv:mypy]
 basepython = python3.6
 deps = mypy
 commands = mypy src/
+skip_install = true
 
 [flake8]
 max-line-length = 99
 max-complexity = 10
 extend_ignore = E731
+skip_install = true
 
 [coverage:report]
 exclude_lines =

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ commands =
     coverage report
     coverage xml
 
+[testenv:isal]
+deps =
+    pytest
+    coverage
+    isal
+
 [testenv:flake8]
 basepython = python3.6
 deps = flake8


### PR DESCRIPTION
This adds python-isal to the mix as an optional dependency. Optional, because it is only available on linux and requires extra libraries to be present.