### PR TITLE
Require isal on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         include:
         - os: macos-latest
           python-version: 3.7

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,8 @@ available. For gzip compression levels 1 to 3,
 For use cases where using only the main thread is desired xopen can be used
 with ``threads=0``. This will use `python-isal
 <https://github.com/pycompression/python-isal>`_ (which binds isa-l) if
-python-isal is installed. For installation instructions for python-isal please
+python-isal is installed (automatic on Linux systems, as it is a requirement).
+For installation instructions for python-isal please
 checkout the `python-isal homepage
 <https://github.com/pycompression/python-isal>`_. If python-isal is not
 available ``gzip.open`` is used.

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ tool <https://cutadapt.readthedocs.io/>`_ that is used in bioinformatics to
 manipulate sequencing data. It has been in successful use within that software
 for a few years.
 
-``xopen`` is compatible with Python versions 3.5 and later.
+``xopen`` is compatible with Python versions 3.6 and later.
 
 
 Usage
@@ -94,6 +94,12 @@ If you also want to open S3 files, you may want to use that module instead.
 
 Changes
 -------
+v1.1.0
+~~~~~~
+* Python 3.5 support is dropped.
+* On Linux systems, `python-isal <https://github.com/pycompression/python-isal`_
+  is now added as a requirement. This will speed up the reading of gzip files
+  significantly when no external processes are used.
 
 v1.0.0
 ~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        'isal': ['isal>=0.2.0']
+        ':sys_platform=="linux"': ['isal>=0.3.0']
     },
     python_requires='>=3.5',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={"xopen": ["py.typed"]},
     extras_require={
         'dev': ['pytest'],
-        ':sys_platform=="linux"': ['isal>=0.3.0']
+        ':sys_platform=="linux" and python_implementation != "PyPy"': ['isal>=0.3.0']
     },
     python_requires='>=3.6',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'dev': ['pytest'],
         ':sys_platform=="linux"': ['isal>=0.3.0']
     },
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,mypy,py35,py36,py37,py38,py39,pypy3
+envlist = flake8,mypy,py36,py37,py38,py39,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Wheels for isal are now build from version 0.3.0 onwards.
Installation is very quick.